### PR TITLE
Fixed 2 issues of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/ps2.py
+++ b/ps2.py
@@ -217,10 +217,10 @@ def lookup(key):
 	c = 0
 	for i in key[0]:
 		if c == 0:
-			if i in "AOEU-*": c+=1
+			if i in "AOEU-*": c += 1
 			else: ks += i
 		if c == 1:
-			if not i in "AOEU-*": c+=1
+			if not i in "AOEU-*": c += 1
 			elif i in "AOEU": km += i
 		if c == 2:
 			ke += i


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.